### PR TITLE
Configure github actions for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  node-tests:
+    name: Node.js Monorepo Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run JS/TS tests
+        run: pnpm -r test
+        env:
+          CI: true
+
+  python-tests:
+    name: Python Package Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - packages/backend
+          - packages/workers
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PDM (Python 3.11)
+        uses: pdm-project/setup-pdm@v4
+        with:
+          python-version: '3.11'
+          cache: true
+
+      - name: Install dependencies
+        run: pdm install -G dev
+
+      - name: Run pytest
+        run: pdm run pytest -q
+


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

CI/CD configuration (new GitHub Actions workflow)

### What is the current behavior?

No automated tests are run on GitHub for this repository.

### What is the new behavior?

A GitHub Actions workflow (`.github/workflows/ci.yml`) is introduced to automatically run tests on `push` to `main`/`master` and on `pull_request` events.
It includes:
- A Node.js job that sets up pnpm, installs dependencies, and runs `pnpm -r test` across all workspaces.
- A Python job that sets up PDM with Python 3.11, installs dev dependencies, and runs `pytest` for `packages/backend` and `packages/workers`.

### Does this PR introduce a breaking change?

No.

### Other information:

---
<a href="https://cursor.com/background-agent?bcId=bc-404f0c47-55ad-4cd9-823f-da0e6a0a42d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-404f0c47-55ad-4cd9-823f-da0e6a0a42d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

